### PR TITLE
Typo fixes

### DIFF
--- a/src/components/Pricing.tsx
+++ b/src/components/Pricing.tsx
@@ -52,7 +52,7 @@ const PRICE_PLANS: IPricePlan[] = [
   },
   {
     title: 'Pro Plan',
-    subTitle: 'For when you\re ready to go live',
+    subTitle: 'For when you\'re ready to go live',
     price: () => (<PriceDisplay amount={15} period="/ mo per site" />),
     active: true,
     detailLines: () => [

--- a/src/content/docs/plugins/form-submit.mdx
+++ b/src/content/docs/plugins/form-submit.mdx
@@ -6,7 +6,7 @@ slug: form-submit
 
 import { Alert, Cli, Image } from '$components/mdx';
 
-The `form-submit` plugin let's you submit HTML forms from your Aerobatic static website. Form submissions are saved in a database on the Aerobatic side that you can view in the dashboard. It's a great solution for contact forms, quote requests, email list subscribes, user surveys, and the like.
+The `form-submit` plugin lets you submit HTML forms from your Aerobatic static website. Form submissions are saved in a database on the Aerobatic side that you can view in the dashboard. It's a great solution for contact forms, quote requests, email list subscribes, user surveys, and the like.
 
 You can optionally specify that form submissions be emailed or posted to a webhook enabling more sophisticated integrations with other services. The webhook feature is especially powerful when used in conjunction with [Zapier](https://zapier.com) which can combine an incoming webhook with lots of popular services like Mailchimp, Salesforce, and many more.
 


### PR DESCRIPTION
- The Pricing component on the homepage has a missing letter caused by an escape `\` with out the `'` afterwards, so instead of reading "you're" it reads "youe".
- Corrected `let's` to `lets` in Form Submit Plugin.